### PR TITLE
fix: Correct post language issues and add correction skill

### DIFF
--- a/.claude/skills/correcting-blog-posts/SKILL.md
+++ b/.claude/skills/correcting-blog-posts/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: correcting-blog-posts
+description: Use when reviewing a manually-written post in src/content/posts for language errors and prose improvements - grammar, spelling, punctuation, subject-verb agreement, awkward phrasing, or voice consistency. Never use to draft new posts, new sections, or open-ended "make it better" rewrites.
+---
+
+# Correcting Blog Posts
+
+## Overview
+
+Posts in `src/content/posts/` are always written by hand by the author, never AI-generated. This skill fixes language errors and proposes prose tightening in the author's existing voice. It never invents content, expands sections, or writes replacement paragraphs.
+
+## When to Use
+
+- Author asks to check, review, proofread, or correct a post
+- After a post is finished but before publishing
+- Spot-checking older posts for lingering errors
+
+## When NOT to Use
+
+- Drafting a new post or a new section - out of scope, the author writes all prose
+- Open-ended "make this post better/more engaging" - that's an editorial call for the author
+- Restructuring, adding new examples, or extending explanations
+
+## The Rule
+
+**Fix errors. Do not add content the author didn't write.**
+
+Every change must be one of:
+
+1. **Grammar/spelling/punctuation fix** - subject-verb agreement, missing possessive, typo, wrong article, tense mismatch.
+2. **Trim** - cut a redundant word or clause without changing meaning.
+3. **Reorder** - same words, clearer order (e.g. fixing a dangling modifier).
+4. **Flagged suggestion** - a prose change that touches meaning or adds words. Proposed as a diff for the author to accept or reject. Never applied silently.
+
+If a fix requires writing a new sentence or expanding an idea, stop. Flag it as a suggestion with the reasoning, and let the author write the replacement.
+
+## Recognizing the Blog's Voice
+
+Read at least 2 existing posts in `src/content/posts/` before editing any one. Voice varies by era, but has consistent fingerprints:
+
+- First person, direct: "I built...", "I chose...", contractions used freely (I've, doesn't, wasn't)
+- Sentence fragments and short declaratives for texture: "No formula.", "That project is X."
+- No em dashes as a stylistic tic. Don't add throat-clearing openers like "In this post, we will explore..." unless the author already wrote one
+- Concrete numbers, tools, and links over vague adjectives
+- Didactic "we" is fine only in explanatory/mathematical passages ("we can approximate the gradient..."), never in first-person narrative about what the author personally built or decided - there it's "I"
+
+## AI-Tell Checklist
+
+Reject any fix that introduces these, even if grammatically correct:
+
+- Filler openers or closers ("In conclusion", "It's worth noting", "Moreover", "Overall")
+- Unnecessary em dashes
+- Symmetric triplets ("clean, fast, and reliable") where the author wrote two items
+- Hedging qualifiers the author didn't use ("arguably", "in many ways")
+- Over-formalizing an intentional fragment into a full sentence
+- A rewritten sentence that ends up longer than the original without adding real information
+
+## Workflow
+
+1. Read the target post fully.
+2. Read 1-2 other posts, ideally from the same era (check `date` in frontmatter), to calibrate voice.
+3. List candidate fixes, each tagged `fix` (apply directly) or `suggestion` (needs author sign-off).
+4. Apply only `fix`-tagged changes, as minimal diffs.
+5. Present `suggestion`-tagged items as a list: original vs proposed, with a one-line reason. Wait for approval before applying.
+6. Never touch code blocks, math (LaTeX/KaTeX), image paths, or frontmatter fields other than an obvious typo in `title`/`description` if flagged.
+
+## Common Mistakes
+
+| Mistake | Why it's wrong |
+|---|---|
+| Rewriting a whole paragraph "while in there" | Scope creep - turns a correction pass into a rewrite, erodes the author's voice |
+| Fixing style you personally dislike but isn't wrong | Not your call - only fix actual errors or explicitly flagged suggestions |
+| Adding transitions or conclusions the post didn't have | That's generation, not correction - forbidden |
+| Applying `suggestion`-tagged prose changes without asking | Silent meaning changes are exactly what makes text read as AI-edited |
+| Skipping the voice-calibration read | Guarantees fixes that don't match the post's era or tone |
+
+## Red Flags - you are about to violate this skill
+
+- "Let me also improve this transition" - stop, that's not a language error
+- "This paragraph would flow better if I added..." - stop, propose as a suggestion, don't add
+- "I'll just rewrite this section for clarity" - stop, rewriting is not correcting
+- About to touch more than one sentence with wording not present in the original - tag as `suggestion`, don't apply

--- a/src/content/posts/distributed-matrix-product.md
+++ b/src/content/posts/distributed-matrix-product.md
@@ -21,7 +21,7 @@ For distribution, I'm using [MPI](https://www.open-mpi.org/) (Message Passing In
 
 ![Distributed matrix product](/images/posts/distributed_matrix_product/mpi_distributed_matrix_multiplication_diagram.svg)
 
-For parallel computation within each node, we leverage GPUs. Each node of MareNostrum III has an NVIDIA K80 graphics card, which can be used for parallel computing via NVIDIA's [CUDA](https://en.wikipedia.org/wiki/CUDA) (Compute Unified Device Architecture) platform. GPUs are essentially large arrays of simple processors that can dramatically speed up certain computations.
+For parallel computation within each node, I leverage GPUs. Each node of MareNostrum III has an NVIDIA K80 graphics card, which can be used for parallel computing via NVIDIA's [CUDA](https://en.wikipedia.org/wiki/CUDA) (Compute Unified Device Architecture) platform. GPUs are essentially large arrays of simple processors that can dramatically speed up certain computations.
 
 The computation is decomposed into many threads that execute concurrently. Each thread calculates a single element of the resulting matrix. CUDA requires defining a block structure (groups of threads), with each thread's data domain determined by its `threadId` and `blockId`.
 

--- a/src/content/posts/news-aggregator.md
+++ b/src/content/posts/news-aggregator.md
@@ -11,11 +11,11 @@ Existing solutions didn't quite cut it. They were either too cluttered, missed t
 
 I used this opportunity to "vibe code" the project from scratch, leveraging **[Antigravity](https://antigravity.google/)** to accelerate the process.
 
-The experience was refreshing. Instead of wrestling with complex configurations for hours, I could focus on the selection of data sources and the design. [Antigravity](https://antigravity.google/) helped specifically with the integration parts, analyzing the data sources website HTML structure and generating the scraping logic, which made the development flow much smoother. It felt like pair programming with a partner who handles the tedious parts while I make the executive decisions.
+The experience was refreshing. Instead of wrestling with complex configurations for hours, I could focus on the selection of data sources and the design. [Antigravity](https://antigravity.google/) helped specifically with the integration parts, analyzing each data source's website HTML structure and generating the scraping logic, which made the development flow much smoother. It felt like pair programming with a partner who handles the tedious parts while I make the executive decisions.
 
 ## The App
 
-**[NewsAggr](https://newsaggr.online/)** is the result. It's an elegant, distraction-free news aggregator designed for focus. I'm gradually adding new features and improving existing ones based on feedback from friends. 
+**[NewsAggr](https://newsaggr.online/)** is the result. It's an elegant, distraction-free news aggregator designed for focus. I'm gradually adding new features and improving existing ones based on feedback from friends.
 
 It features:
 - **Unified Feed**: All my tech and news sources in one place.

--- a/src/content/posts/sinsesgo.md
+++ b/src/content/posts/sinsesgo.md
@@ -8,7 +8,7 @@ For years I’ve read Spanish news with a thumb on the scroll bar and one eye on
 
 [Ground News](https://ground.news/daily-briefing) does this for the English-speaking world. Their daily briefing was the inspiration. But Ground News does not cover Spanish outlets in any meaningful depth, and most of their bias signal comes from the source label, not from the content of each article. I wanted something focused on Spain, that read every article in full, and that ran on its own every day without me touching it.
 
-That project is **[sinsesgo](https://sinsesgo.es)**. Every day, a cron job pulls articles from 18 Spanish outlets, clusters them by topic, picks the five most covered stories of the day, analyze them through a pipeline of agents, and builds a briefing that contrasts how the left, center and right framed each one. No login, no paywall, no human in the loop.
+That project is **[sinsesgo](https://sinsesgo.es)**. Every day, a cron job pulls articles from 18 Spanish outlets, clusters them by topic, picks the five most covered stories of the day, analyzes them through a pipeline of agents, and builds a briefing that contrasts how the left, center and right framed each one. No login, no paywall, no human in the loop.
 
 This post is for the technical readers who land on the [funcionamiento page](https://sinsesgo.es/funcionamiento) and want the long version. I will walk through the pipeline end to end: data ingestion, embeddings, clustering, and the agents that do the analysis. I will also explain a second use case that lives in the codebase but does not run in production, and why.
 


### PR DESCRIPTION
## Why

Language slips in three posts (a subject-verb agreement error, an ambiguous possessive, a pronoun inconsistency, and a stray trailing space), and there was no repeatable way to catch these on future posts without risking an AI-flattened voice.

## What changed

- Fixed the language issues above in `sinsesgo.md`, `news-aggregator.md`, and `distributed-matrix-product.md`
- Added a `correcting-blog-posts` skill that fixes language errors and flags meaning-changing prose suggestions for approval, and never drafts new content - posts stay hand-written

## Test procedure

- Reviewed each edited sentence against its surrounding paragraph for consistency
- Read the new skill against the existing posts' voice to confirm its guardrails match how the blog actually reads
